### PR TITLE
Update CyberArkAIM_v2.py

### DIFF
--- a/Packs/cyberark_AIM/Integrations/CyberArkAIM_v2/CyberArkAIM_v2.py
+++ b/Packs/cyberark_AIM/Integrations/CyberArkAIM_v2/CyberArkAIM_v2.py
@@ -127,7 +127,7 @@ def fetch_credentials(client, args: dict):
             {
                 "user": cred.get("UserName"),
                 "password": cred.get("Content"),
-                "name": cred.get("Name"),
+                "name": cred.get("Name") or cred.get("Object"),
             }
         )
     demisto.credentials(credentials)


### PR DESCRIPTION
Add support for cyberark >= 14.2 where Property "Object" must be used instead of "Name"

https://community.cyberark.com/s/article/Why-does-the-CCP-14-2-Password-Retrieval-response-include-a-Parameter-Object-instead-of-a-Parameter-Name-unlike-previous-versions

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Add support for cyberark >= 14.2 where Property "Object" must be used instead of "Name"

https://community.cyberark.com/s/article/Why-does-the-CCP-14-2-Password-Retrieval-response-include-a-Parameter-Object-instead-of-a-Parameter-Name-unlike-previous-versions

## Must have
- [ ] Tests
- [ ] Documentation 
